### PR TITLE
Fix Typo in One-Hot Encode Nominal Categorical Features

### DIFF
--- a/content/machine-learning/one-hot_encode_nominal_categorical_features.ipynb
+++ b/content/machine-learning/one-hot_encode_nominal_categorical_features.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Load libraries\n",
-    "from sklearn.preprocessing import LabelBinarizerr\n",
+    "from sklearn.preprocessing import LabelBinarizer\n",
     "import numpy as np\n",
     "import pandas as pd"
    ]

--- a/content/machine-learning/one-hot_encode_nominal_categorical_features.md
+++ b/content/machine-learning/one-hot_encode_nominal_categorical_features.md
@@ -15,7 +15,7 @@ Authors: Chris Albon
 
 ```python
 # Load libraries
-from sklearn.preprocessing import LabelBinarizerr
+from sklearn.preprocessing import LabelBinarizer
 import numpy as np
 import pandas as pd
 ```


### PR DESCRIPTION
Fixed a small typo in [One-Hot Encode Nominal Categorical Features](https://chrisalbon.com/machine-learning/one-hot_encode_nominal_categorical_features.html)

Changed `LabelBinarizerr` to `LabelBinarizer`